### PR TITLE
Using the locally installed bower cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "shelljs": "^0.2.6"
   },
   "scripts": {
-    "postinstall": "bower install",
+    "postinstall": "node_modules/.bin/bower install",
     "prestart": "npm install",
     "start": "http-server -a localhost -p 8000",
     "pretest": "npm install",


### PR DESCRIPTION
Since bower is intalled thanks to package.json better use that specific version instead of relying on the system one